### PR TITLE
temp fix to issues with yokogawa source

### DIFF
--- a/src/qnnpy/functions/functions.py
+++ b/src/qnnpy/functions/functions.py
@@ -1270,7 +1270,7 @@ class Instruments:
                 properties[inst_name]["port"],
                 properties[inst_name].get("port_alt", None),  # Handle optional port_alt
             )
-            source.reset()  # Assuming reset is a common function for all sources
+            #source.reset()  # Assuming reset is a common function for all sources \\EB: I think resetting the source here can be annoying
             source.set_output(False)  # Assuming this is a common configuration step
             self.instrument_dict[inst_name] = source
             print(f"SOURCE{appender}: connected")

--- a/src/qnnpy/instruments/yokogawa_gs200.py
+++ b/src/qnnpy/instruments/yokogawa_gs200.py
@@ -13,7 +13,7 @@ import pyvisa
 
 
 class YokogawaGS200(object):
-    def __init__(self, visa_name):
+    def __init__(self, visa_name, portalt=None):
         rm = pyvisa.ResourceManager()
         self.pyvisa = rm.open_resource(visa_name)
         self.pyvisa.timeout = 5000  # Set response timeout (in milliseconds)


### PR DESCRIPTION
adds unused "portalt" param to Yokogawa source because it's needed due to some kind of changes for SRS compatibility. commented out "source.reset()" as default on source initialization because it's annoying to manually set up the Yokogawa how I want and have it reset when I want to run any code with it, and I'm not sure it's needed